### PR TITLE
Add support for fake FTDI chips and fix bug that prevents Windows to communicate with 4xidraw

### DIFF
--- a/inkscape driver/grbl_serial.py
+++ b/inkscape driver/grbl_serial.py
@@ -16,7 +16,8 @@ def findPort():
     if comports:
 	comPortsList = list(comports())
 	for port in comPortsList:
-	    if port[1].startswith("USB2.0-Serial"): # Works for Ubuntu
+	    desc = port[1].lower()
+	    if "usb" in desc and "serial" in desc:
 		return port[0]
     return None
 
@@ -29,7 +30,7 @@ def testPort(comPort):
 	try:
 	    serialPort = serial.Serial(comPort, baudrate = 115200, timeout = 1.0,
                                        rtscts = False,
-                                       dsrdtr = True)
+                                       dsrdtr = False)
             time.sleep(2)
             while True:
 	        strVersion = serialPort.readline()

--- a/inkscape driver/grbl_serial.py
+++ b/inkscape driver/grbl_serial.py
@@ -28,7 +28,13 @@ def testPort(comPort):
     '''		
     if comPort is not None:
 	try:
-	    serialPort = serial.Serial(comPort, baudrate = 115200, timeout = 1.0)
+	    serialPort = serial.Serial()
+            serialPort.baudrate = 115200
+            serialPort.timeout = 1.0
+            serialPort.rts = False
+            serialPort.dtr = True
+            serialPort.port = comPort
+            serialPort.open()
             time.sleep(2)
             while True:
 	        strVersion = serialPort.readline()

--- a/inkscape driver/grbl_serial.py
+++ b/inkscape driver/grbl_serial.py
@@ -28,9 +28,7 @@ def testPort(comPort):
     '''		
     if comPort is not None:
 	try:
-	    serialPort = serial.Serial(comPort, baudrate = 115200, timeout = 1.0,
-                                       rtscts = False,
-                                       dsrdtr = False)
+	    serialPort = serial.Serial(comPort, baudrate = 115200, timeout = 1.0)
             time.sleep(2)
             while True:
 	        strVersion = serialPort.readline()


### PR DESCRIPTION
- Support any USB serial driver by not hard-coding that starts with "XY". Instead check are "usb" and "serial" in description e.g. my fake FTDI chip's name is "USB-SERIAL CH340..."
- Windows is not supporting the original "serial.Serial()" declaration. When "dsrdtr" set to True it fails to communicate with the Arduino board. If we pass dtr before port declaration and open() it is working like a charm. Maybe good idea to test this on Linux just to make sure it is still working