### PR TITLE
Fixed Arduino detection on some linux-based systems

### DIFF
--- a/inkscape driver/grbl_serial.py
+++ b/inkscape driver/grbl_serial.py
@@ -18,7 +18,7 @@ def findPort():
         for port in comPortsList:
             desc = port[1].lower()
             isUsbSerial = "usb" in desc and "serial" in desc
-            isArduino = "arduino" in desc 
+            isArduino = "arduino" in desc or "acm" in desc
             isCDC = "CDC" in desc 
             if isUsbSerial or isArduino or isCDC:
                 return port[0]


### PR DESCRIPTION
On my system (arch linux), arduinos are listed as `ttyACM0`. My pull request fixes an issue of 4xidraw not being detected in this case.