### PR TITLE
Support Inkscape 1.0.1

### DIFF
--- a/inkscape driver/fourxidraw_compat.py
+++ b/inkscape driver/fourxidraw_compat.py
@@ -1,0 +1,113 @@
+# fourxidraw_compat.py
+#
+# Part of the 4xiDraw driver for Inkscape
+# 
+# This offers functions to bridge non-compatible changes between pre- and post-1.0 versions of Inkscape.
+# 
+# See https://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+import builtins
+import sys
+# old
+import cspsubdiv
+from bezmisc import *
+from simpletransform import *
+# new
+from inkex import bezier
+from inkex import paths
+
+def isPython3():
+    return sys.version_info[0] == 3
+
+# Convert from typenames to types
+def compatGetArgumentTypeFromName(type_name):
+    try:
+        # Cater for non-built-in type as per
+        # https://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0#Collecting_the_options_of_the_extension
+        if type_name == 'inkbool':
+            return inkex.Boolean
+            
+        return getattr(builtins, type_name)
+    except AttributeError:
+        return None
+
+# DeprecationWarning: inkex.bezier.beziersplitatt -> Split bezier at given time
+def compatBezierSplitAtT(b, t):
+
+    if isPython3():
+        return bezier.beziersplitatt( b, t )
+    else:
+        return beziersplitatt( b, t )        
+        
+# DeprecationWarning: inkex.bezier.maxdist -> Get maximum distance within bezier curve
+def compatCspSubDivMaxDist(b):
+
+    if isPython3():
+        return bezier.maxdist( b )
+    else:
+        return cspsubdiv.maxdist( b )
+        
+# DeprecationWarning: simpletransform.parseTransform -> Transform(str).matrix
+def compatParseTransform(stringRepresentation):
+
+    if isPython3():
+        return Transform(stringRepresentation).matrix
+    else:
+        return simpletransform.parseTransform(stringRepresentation)
+
+# DeprecationWarning: simpletransform.composeTransform -> Transform(M1) * Transform(M2)
+def compatComposeTransform(a, b):
+
+    if isPython3():
+        return Transform(a) * Transform(b)
+    else:
+        return composeTransform(a, b)
+        
+# DeprecationWarning: simplepath.parsePath -> element.path.to_arrays()
+def compatIsEmptyPath(stringRepresentation):
+
+    if isPython3():
+        return len(Path(stringRepresentation).to_arrays()) == 0
+    else:
+        return len(simplepath.parsePath(stringRepresentation)) == 0
+        
+# DeprecationWarning: cubicsuperpath.parsePath -> None
+def compatParseCubicSuperPath(stringRepresentation):
+
+    if isPython3():
+        return paths.CubicSuperPath(paths.Path(stringRepresentation))
+    else:
+        return cubicsuperpath.parsePath(stringRepresentation)
+
+# This one looks like changed behaviour with no deprecation warning!
+# 
+# From the code, it looks like Inkscape 0.9.x transformed the path in place. That isn't how
+# Inkscape 1.x works - its "applyTransformToPath" does NOT modify p.
+# 
+# If the path isn't modified, documents with a size expressed in mm instead of inches
+# (e.g. examples/AxiDraw_First.svg, which has height="210mm", width="297mm") will not plot correctly -
+# the transform will not affect the path and as a result we'll get a path in mm being interpreted as
+# being in inches - the practical effect being to lock everything to the maximum coordinates.
+# By contrast, files such as examples/basic demos/HappyBirthday.svg have their height and witdth in
+# inches, and so get through OK.
+def compatApplyTransformToPath(matTransform, p):
+    
+    if isPython3():
+        return inkex.paths.CubicSuperPath(Path(p).transform(Transform(matTransform)))
+    else:
+        applyTransformToPath(matTransform, p)
+        return p

--- a/inkscape driver/plot_utils.py
+++ b/inkscape driver/plot_utils.py
@@ -34,6 +34,8 @@ from math import sqrt
 import cspsubdiv
 from bezmisc import *
 
+import fourxidraw_compat # To bridge Python 2/3, Inkscape 0.*/1.*
+
 def version():
 	return "0.5"	# Version number for this document
 
@@ -177,11 +179,11 @@ def subdivideCubicPath( sp, flat, i=1 ):
 
 			b = ( p0, p1, p2, p3 )
 
-			if cspsubdiv.maxdist( b ) > flat:
+			if fourxidraw_compat.compatCspSubDivMaxDist( b ) > flat:
 				break
 			i += 1
 
-		one, two = beziersplitatt( b, 0.5 )
+		one, two = fourxidraw_compat.compatBezierSplitAtT( b, 0.5 )
 		sp[i - 1][2] = one[1]
 		sp[i][0] = two[2]
 		p = [one[2], one[3], two[1]]


### PR DESCRIPTION
This version will run in Inkscape 1.0.1's native version of Python3 with no changes required: all you need to do is copy the "inkscape driver" files into the "extensions" directory - or a subdirectory of it (think support for that might be an Inkscape 1.x thing?).

Note that what I **don't** have is a working Inkscape 0.9.x setup with whatever hacks people commonly use with Python2 versions of PySerial etc. So I don't have 100% confidence that my legacy Python2 code paths don't have an error - they are just cut-and-pasting existing code, but there's always the chance of a typo. 

The bulk of the changes are to be found in the new module fourxidraw_compat.py. New behaviour is triggered via the isPython3() check in that module. See https://wiki.inkscape.org/wiki/index.php/Updating_your_Extension_for_1.0 for the kinds of changes that were necessary.

Main points to note:

1) grbl_serial.py testPort() has code added to cater for serialPort.open() resetting the Arduino. This does happen on my system, but I don't know if it can also happen to systems running older versions of Inkscape. The symptom would be "Error: Unexpected response from GRBL." as a command received an unexpected "Grbl" message. Making it apply to all versions might help others, but would add up to 2 seconds on setups where serialPort.open() did not reset the Arduino.

2) Also in grbl_serial.py, I've had to fix a number of things up to cater for Python3 strings being unicode, and so no longer directly convertible to and from the byte-arrays sent and received by PySerial.

3) All deprecation warnings have been fixed, but Python2 code paths have been kept. Note that I haven't actually verified Python2/Inkscape 0.9.x operation as I don't have this set up.

4) There was a further nasty case where it looks like there was a silent change in behaviour for applyTransformToPath() - in Inkscape 1.x this does **not** modify the path in place, but the extension code clearly assumes it does do this - so I presume the Inkscape 0.9.x code must have worked in this fashion, otherwise no-one would have been able to plot anything with a size specified in mm rather than inches! Workaround is in fourxidraw_compat.py, compatApplyTransformToPath() method.