### PR TITLE
A few minor Python3 fixes

### DIFF
--- a/inkscape driver/fourxidraw.py
+++ b/inkscape driver/fourxidraw.py
@@ -431,7 +431,7 @@ class FourxiDrawClass(inkex.Effect):
     self.recursiveWCBDataScan(self.svg)
     if self.options.fileOutput:
       if (not self.svgDataRead): # if there is no WCB data, add some:
-        WCBlayer = inkex.etree.SubElement(self.svg, 'WCB')
+        WCBlayer = fourxidraw_compat.compatEtreeSubElement(self.svg, 'WCB')
         WCBlayer.set('layer', str(0))
         WCBlayer.set('node', str(0))      # node paused at, if saved in paused state
         WCBlayer.set('lastpath', str(0))    # Last path number that has been fully painted

--- a/inkscape driver/fourxidraw_compat.py
+++ b/inkscape driver/fourxidraw_compat.py
@@ -52,6 +52,15 @@ def compatGetArgumentTypeFromName(type_name):
     except AttributeError:
         return None
 
+def compatPxPerInch():
+
+    if isPython3():
+        # Inkscape 1.x follows the SVG specification of 96 px per inch
+        return 96.0
+    else:
+        # 90 px per inch, as of Inkscape 0.91
+        return 90.0
+
 # DeprecationWarning: inkex.etree was removed, use "from lxml import etree"
 def compatEtreeElement(elem):
 
@@ -59,6 +68,14 @@ def compatEtreeElement(elem):
         return etree.Element(elem)
     else:
         return inkex.etree.Element(elem)
+
+# DeprecationWarning: inkex.etree was removed, use "from lxml import etree"
+def compatEtreeSubElement(a, b):
+
+    if isPython3():
+        return etree.SubElement(a, b)
+    else:
+        return inkex.etree.SubElement(a, b)
 
 # Behaviour change: 0.9.x accepts (requires?) spaces between commands and other elements, 1.x rejects them
 # This may be a consequence of simplepath.FormatPath(a) being deprecated/replaced by str(Path(a)) and differences in the relevant code

--- a/inkscape driver/plot_utils.py
+++ b/inkscape driver/plot_utils.py
@@ -39,9 +39,7 @@ import fourxidraw_compat # To bridge Python 2/3, Inkscape 0.*/1.*
 def version():
 	return "0.5"	# Version number for this document
 
-pxPerInch = 90.0	# 90 px per inch, as of Inkscape 0.91
-					# Note that the SVG specification is for 96 px per inch; 
-					# Expect a change to 96 as of Inkscape 0.92.
+pxPerInch = fourxidraw_compat.compatPxPerInch()
 
 def distance( x, y ):
 	'''
@@ -153,6 +151,8 @@ def getLengthInches( altself, name ):
 			return (float( v ) / 6.0)	
 		elif u == 'pt':
 			return (float( v ) / 72.0)
+		elif u == 'px':
+			return (float( v ) / pxPerInch)
 		else:
 			# Unsupported units
 			return None


### PR DESCRIPTION
1) Provide compatibility shim for index.etree.SubElement(), to avoid deprecation warning
2) Change pxPerInch (pixels per inch) so it's 96 for Inkscape 1.x (rather than the 90 used by Inkscape 0.9.x)
3) Fix getLengthInches() so it supports documents with size in px - otherwise attempting to draw them crashes