### PR TITLE
Python 3 fix for basestring, and allow sending GRBL commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ $132=200.000
 $N0=M3S90
 ```
 
-
 ---------
 
 ## Dependencies
 
-This extensions requires some python modules and and Inkscape extensions to be installed.
+The main extension "4xiDraw/4xiDraw Control..." should work directly with Inkscape 1.0.1, but Inkscape 0.9.x will require some python modules and and Inkscape extensions to be installed, as set out below.
+
+Note that the "4xiDraw/Hatch Fill..." extension is not yet tested with Inkscape 1.0.1.
 
 ### Python Modules
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $N0=M3S90
 
 The main extension "4xiDraw/4xiDraw Control..." should work directly with Inkscape 1.0.1, but Inkscape 0.9.x will require some python modules and and Inkscape extensions to be installed, as set out below.
 
-Note that the "4xiDraw/Hatch Fill..." extension is not yet tested with Inkscape 1.0.1.
+Note that the "4xiDraw/Hatch Fill..." extension has not yet been upgraded to work with Inkscape 1.0.1/Python3.
 
 ### Python Modules
 

--- a/inkscape driver/4xidraw.inx
+++ b/inkscape driver/4xidraw.inx
@@ -83,7 +83,6 @@ You can use this tab to send "manual" commands to the
 pen, or test communication
 with the machine.
 </_param>
-
 <param name="manualType" type="optiongroup" appearance="minimal"
 _gui-text="               Command: ">
 <_option value="none"           >- Select -</_option>
@@ -93,11 +92,12 @@ _gui-text="               Command: ">
 <_option value="walk-y-motor"   >Walk Carriage (Y)</_option>
 <_option value="version-check"  >Check GRBL Version</_option>
 <_option value="strip-data"     >Strip plotter data from file</_option>
+<_option value="grbl-command"   >Issue GRBL command</_option>
 </param>
 
-<param name="WalkDistance" type="float" min="-11" max="11" 
-_gui-text="Walk distance in inches (+ or -):">1.00</param>
+<param name="grblCommand" type="string" _gui-text="GRBL command:">$$</param>
 
+<param name="WalkDistance" type="float" min="-11" max="11" _gui-text="Walk distance in inches (+ or -):">1.00</param>
 
 <_param  indent="1" name="instructions_manual2" type="description" >
 Note: The manual "walk" commands move the motors

--- a/inkscape driver/fourxidraw.py
+++ b/inkscape driver/fourxidraw.py
@@ -169,6 +169,11 @@ class FourxiDrawClass(inkex.Effect):
       dest="WalkDistance", default=1,
       help="Distance for manual walk")
 
+    self.compat_add_option("--grblCommand",
+      action="store", type="string",
+      dest="grblCommand", default="$$",
+      help="GRBL command to execute")
+
     self.compat_add_option("--resumeType",
       action="store", type="string",
       dest="resumeType", default="ResumeNow",
@@ -511,6 +516,10 @@ class FourxiDrawClass(inkex.Effect):
     elif self.options.manualType == "version-check":
       strVersion = self.serialPort.query('$I\r')
       inkex.errormsg('I asked GRBL for its version info, and it replied:\n ' + strVersion)
+
+    elif self.options.manualType == "grbl-command":
+      strResponse = self.serialPort.query(self.options.grblCommand + '\r')
+      inkex.errormsg('GRBL command "' + self.options.grblCommand + '" got this reply:\n ' + strResponse)
 
     else:  # self.options.manualType is walk motor:
       if self.options.manualType == "walk-y-motor":
@@ -1012,7 +1021,7 @@ class FourxiDrawClass(inkex.Effect):
         elif node.tag == inkex.addNS('color-profile', 'svg') or node.tag == 'color-profile':
           # Gamma curves, color temp, etc. are not relevant to single color output
           pass
-        elif not isinstance(node.tag, basestring):
+        elif not fourxidraw_compat.compatIsBasestring(node.tag):
           # This is likely an XML processing instruction such as an XML
           # comment.  lxml uses a function reference for such node tags
           # and as such the node tag is likely not a printable string.

--- a/inkscape driver/fourxidraw_compat.py
+++ b/inkscape driver/fourxidraw_compat.py
@@ -52,6 +52,13 @@ def compatGetArgumentTypeFromName(type_name):
     except AttributeError:
         return None
 
+def compatIsBasestring(obj):
+
+    if isPython3():
+        return isinstance(obj, str)
+    else:
+        return isinstance(obj, basestring)
+
 def compatPxPerInch():
 
     if isPython3():

--- a/inkscape driver/grbl_serial.py
+++ b/inkscape driver/grbl_serial.py
@@ -151,14 +151,16 @@ class GrblSerial(object):
                         self.log('QUERY', 'read %d' % nRetryCount)
                     response = self.readline()
                     nRetryCount += 1
-                    if self.doLog:
-                        self.log('QUERY', 'response is '+response)
+                    
                 # swallow 'ok'
-                nRetryCount = 0
-                ok = self.readline()
-                while (len(ok) == 0) and (nRetryCount < 100):
-                    ok = self.readline()
-                    nRetryCount += 1
+                extra = self.readline()
+                while (len(extra) > 0 and extra != 'ok'):
+                    if self.doLog:
+                        self.log('QUERY', 'read extra: ' + extra)
+                    response = response + '\r' + extra
+                    extra = self.readline()
+                if self.doLog:
+                    self.log('QUERY', 'response is '+response)
             except serial.SerialException:
                 inkex.errormsg(gettext.gettext("Error reading serial data."))
             return response


### PR DESCRIPTION
Further PR with 2 changes

1) Add compatibility shim for "basestring" logic in fourxidraw.py - this type doesn't exist in Python3 so the code crashes currently if it gets hit

2) Support a new Manual tab mode "Issue GRBL Command" - this allows users to issue any command and view the full multi-line response. E.g. "$$" will show all the normal settings. Allows quaery and adjustment of motor speed/accel/etc without having to switch over to Arduino Serial Monitor or similar.