### PR TITLE
Enable different speeds for pen up/pen down (disabled by default)

### DIFF
--- a/inkscape driver/4xidraw.inx
+++ b/inkscape driver/4xidraw.inx
@@ -45,13 +45,25 @@ of the pen for writing and drawing.
 
 <page name='timing' _gui-text='Timing'>
 <_param name="instructions_timing1" type="description" appearance="header">Movement speeds:</_param>
-<param indent="1" name="penDownSpeed" type="int" min="1" max="110" _gui-text="Writing/Drawing speed (%):">25</param>	
-<param indent="1" name="penUpSpeed" type="int" min="1" max="110" _gui-text="Pen-up movement speed (%):">75</param>
+<_param indent="1" name="instructions_timing1" type="description"  >
+Set speeds here if you want to draw more slowly with the pen down. The speeds are in GRBL units
+for $110/$111: mm/min. This is useful if you are drawing with pens that can't supply ink above
+a certain speed: for instance Sakura Gelly Roll Moonlight pens start losing flow at about
+1,000 while Metallic pens are good at 2,000. When in this situation, enabling different speeds
+will let you keep pen-up speeds higher.
+</_param>
+<param indent="1" name="applySpeed" type="boolean" _gui-text="Whether to apply speeds to pen">false</param>	
+<param indent="1" name="penDownSpeed" type="int" min="1" max="10000" _gui-text="Writing/Drawing speed (mm/min):">1000</param>	
+<param indent="1" name="penUpSpeed" type="int" min="1" max="10000" _gui-text="Pen-up movement speed (mm/min):">5000</param>
 
 <_param name="instructions_timing3" type="description" appearance="header">Pen lift and lowering speeds:</_param>
-<param indent="1" name="penLiftRate" type="int" min="20" max="500" _gui-text="Pen raising speed (%/s):">150</param>
+<_param indent="1" name="instructions_timing3" type="description"  >
+Fine-tune speeds here - a higher speed will mean you waste less time waiting to move
+after raising or lowering the pen.
+</_param>
+<param indent="1" name="penLiftRate" type="int" min="20" max="1000" _gui-text="Pen raising speed (servo steps/s):">150</param>
 <param indent="1" name="penLiftDelay" type="int" min="-500" max="500" _gui-text="Added delay after raising pen (ms):">0</param>
-<param indent="1" name="penLowerRate" type="int" min="20" max="500" _gui-text="Pen lowering speed (%/s):">150</param>
+<param indent="1" name="penLowerRate" type="int" min="20" max="1000" _gui-text="Pen lowering speed (servo steps/s):">150</param>
 <param indent="1" name="penLowerDelay" type="int" min="-500" max="500" _gui-text="Added delay after lowering pen (ms):">0</param>
 
 <_param indent="2" name="instructions_timing4" type="description" xml:space="preserve">

--- a/inkscape driver/fourxidraw.py
+++ b/inkscape driver/fourxidraw.py
@@ -101,15 +101,20 @@ class FourxiDrawClass(inkex.Effect):
       dest="setupType", default="align-mode",
       help="The setup option selected")
 
+    self.compat_add_option("--applySpeed",
+      action="store", type="inkbool",
+      dest="applySpeed", default=fourxidraw_conf.applySpeed,
+      help="Whether to apply pen speeds")
+
     self.compat_add_option("--penDownSpeed",
       action="store", type="int",
       dest="penDownSpeed", default=fourxidraw_conf.PenDownSpeed,
-      help="Speed (step/sec) while pen is down")
+      help="Speed (mm/min) while pen is down")
 
     self.compat_add_option("--penUpSpeed",
       action="store", type="int",
       dest="penUpSpeed", default=fourxidraw_conf.PenUpSpeed,
-      help="Rapid speed (percent) while pen is up")
+      help="Rapid speed (mm/min) while pen is up")
 
     self.compat_add_option("--penLiftRate",
       action="store", type="int",
@@ -1379,7 +1384,7 @@ class FourxiDrawClass(inkex.Effect):
       vTime += self.options.penLiftDelay  
       if (vTime < 0): # Do not allow negative delay times
         vTime = 0 
-      self.motion.sendPenUp(vTime)    
+      self.motion.sendPenUp(vTime, self.options.penUpSpeed if self.options.applySpeed else None)    
       if (vTime > 50):
         if self.options.mode != "manual":
           time.sleep(float(vTime - 10)/1000.0)  # pause before issuing next command
@@ -1400,7 +1405,7 @@ class FourxiDrawClass(inkex.Effect):
         vTime += self.options.penLowerDelay 
         if (vTime < 0): # Do not allow negative delay times
           vTime = 0
-        self.motion.sendPenDown(vTime)            
+        self.motion.sendPenDown(vTime, self.options.penDownSpeed if self.options.applySpeed else None)            
         if (vTime > 50):
           if self.options.mode != "manual":
             time.sleep(float(vTime - 10)/1000.0)  # pause before issuing next command

--- a/inkscape driver/fourxidraw_conf.py
+++ b/inkscape driver/fourxidraw_conf.py
@@ -31,8 +31,9 @@ If you are operating the 4xiDraw in "standalone" mode, that is, outside
 PenUpPos = 40			# Default pen-up position
 PenDownPos = 0			# Default pen-down position
 
-PenUpSpeed = 75
-PenDownSpeed = 25
+applySpeed = False      # Whether to apply speeds to GRBL for pen up and pen down
+PenUpSpeed = 5000       # Speed when pen up (mm/min)
+PenDownSpeed = 1000     # Speed when pen down (mm/min)
 
 penLowerDelay = 0		# added delay (ms) for the pen to go down before the next move
 penLiftDelay = 0		# added delay (ms) for the pen to go up before the next move

--- a/inkscape driver/grbl_motion.py
+++ b/inkscape driver/grbl_motion.py
@@ -37,15 +37,29 @@ class GrblMotion(object):
     if (self.port is not None):
       return False; # TODO
 
-  def sendPenUp(self, PenDelay):
+  def sendPenUp(self, PenDelay, fSpeed):
     if (self.port is not None):
       strOutput = 'M3 S' + str(self.penUpPosition) + '\r'
       self.port.command(strOutput)
+      if not fSpeed is None:
+        strOutput = 'G4 P0' + '\r'
+        self.port.command(strOutput)
+        strOutput = f'$110={fSpeed}' + '\r'
+        self.port.command(strOutput)
+        strOutput = f'$111={fSpeed}' + '\r'
+        self.port.command(strOutput)
       strOutput = 'G4 P' + str(PenDelay/1000.0) + '\r'
       self.port.command(strOutput)
 
-  def sendPenDown(self, PenDelay):
+  def sendPenDown(self, PenDelay, fSpeed):
     if (self.port is not None):
+      if not fSpeed is None:
+          strOutput = 'G4 P0' + '\r'
+          self.port.command(strOutput)
+          strOutput = f'$110={fSpeed}' + '\r'
+          self.port.command(strOutput)
+          strOutput = f'$111={fSpeed}' + '\r'
+          self.port.command(strOutput)
       strOutput = 'M3 S' + str(self.penDownPosition) + '\r'
       self.port.command(strOutput)
       strOutput = 'G4 P' + str(PenDelay/1000.0) + '\r'


### PR DESCRIPTION
This adds a (default-off) checkbox "Whether to apply speeds to pen" to the "Movement speeds" section of the "Timing" tab.

If this checkbox is enabled, then the "Writing/Drawing speed" and "Pen-up movement speed" settings, which have hitherto had no effect for 4xidraw, will be used to set the GRBL $110/$111 speeds (using the GRBL mm/min units) for pen-down and pen-up respectively. This is useful when using pens that have a limited speed before losing ink flow - e.g. Sakura Gelly Roll pens can take up to around 1,000 mm/min (Moonlight) or 2,000 mm/min (Metallic) before visible flow loss - flow loss is particularly noticeable when filling larger areas, when the pen has space for GRBL to potentially accelerate it to high speeds.

If the checkbox is left to its default unchecked state, the behaviour of the 4xidraw addin is unchanged.

Also on the "Timing" tab, the displayed units for the penLiftRate/penLowerRate settings have also been adjusted to reflect their relationship with the number of servo steps being applied.